### PR TITLE
Fix recipe to work with latest rattler-build release

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  python_min: 3.10
+  python_min: "3.10"
   name: repo-review
   version: "0.12.3"
 
@@ -12,7 +12,7 @@ source:
   sha256: 529d5a0bd60c3c2de81f7be2d9ae8cc442277abc7d763a92d5bef90c596248c2
 
 build:
-  number: 1
+  number: 0
   noarch: python
   script: python -m pip install . -v
   python:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -57,7 +57,7 @@ tests:
       run:
         - pip
         - pytest
-        - sp-repo-review
+        - sp-repo-review==2025.11.07
         - validate-pyproject >=0.14
         - python ${{ python_min }}.*
     script:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 529d5a0bd60c3c2de81f7be2d9ae8cc442277abc7d763a92d5bef90c596248c2
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: python -m pip install . -v
   python:
@@ -59,7 +59,7 @@ tests:
         - pytest
         - sp-repo-review
         - validate-pyproject >=0.14
-        - python ==${{ python_min }}.*
+        - python ${{ python_min }}.*
     script:
       - repo-review --help
       - validate-pyproject -E repo-review --help

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/scientific-python/repo-review/archive/refs/tags/v${{ version }}.tar.gz
-  sha256: 529d5a0bd60c3c2de81f7be2d9ae8cc442277abc7d763a92d5bef90c596248c2
+  sha256: 018f0150d41adb266c1c0a4966e9a2234fb15e3d7810175520398bdae95903ef
 
 build:
   number: 0


### PR DESCRIPTION
The `.*` glob pattern is incompatible with `==` and `>=` operators. Use bare glob `X.Y.*` instead of `==X.Y.*`, and `>=X.Y` instead of `>=X.Y.*`.